### PR TITLE
No need to set relative path in package.json scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   },
   "homepage": "https://github.com/Promo/scrollissimo",
   "scripts": {
-    "mocha": "./node_modules/.bin/mocha",
-    "lint": "./node_modules/.bin/eslint ./lib/scrollissimo.js",
+    "mocha": "mocha",
+    "lint": eslint lib/scrollissimo.js",
     "test": "npm run lint && npm run mocha"
   },
   "devDependencies": {


### PR DESCRIPTION
NPM understand, if there isn't global module and uses node_modules/.bin.